### PR TITLE
Tumblr API "tags"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,8 @@ This should run with at least Python 2.4.
 	penatibus et magnis dis parturient montes, nascetur ridiculus mus. 
 	Pellentesque porttitor mi id felis. Maecenas nec augue. Praesent a quam 
 	pretium leo congue accumsan.</p>'
+    >>> t.posts[4].tags
+    [u'lorem', u'ipsum', u'dolor', u'sit', u'amet']
 
 ## Dependencies ##
 

--- a/tumblr.py
+++ b/tumblr.py
@@ -635,6 +635,9 @@ def parse(url_or_file, cache_dir=DEFAULT_HTTP_CACHE_DIR, proxy_info=None):
             post = Audio(postdata)
         else:
             post = Post(postdata)
+        # Populate a list of tags, if any
+        tags = postdata.findall('tag')
+        post.tags = [unicode(tag.text) for tag in tags]
         # Get the source feed, if present
         try:
             if post.source_feed_id:


### PR DESCRIPTION
Hi there,

I added a few lines to the parse() function in the tumblr module to allow easy access to a post's tags as well (example added to README.markdown). It basically returns a list of unicode tags or an empty list.

Thanks for the code - been using it on my site for a while now.

Paul
